### PR TITLE
Add Vitest tests for BigQuery helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,14 +10,16 @@
     "build:client": "pnpm --filter @onepipe/client run build",
     "build:core": "pnpm --filter @onepipe/core run build",
     "build:destination-bigquery": "pnpm --filter @onepipe/destination-bigquery run build",
-    "dev:client": "pnpm --filter @onepipe/client run dev"
+    "dev:client": "pnpm --filter @onepipe/client run dev",
+    "test": "vitest"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250603.0",
     "@types/lodash": "^4.17.16",
     "@types/uuid": "^10.0.0",
     "typescript": "^5.8.3",
-    "wrangler": "^4.13.2"
+    "wrangler": "^4.13.2",
+    "vitest": "^1.5.0"
   },
   "dependencies": {
     "@maccman/web-auth-library": "^1.0.5",

--- a/packages/destination-bigquery/events/__tests__/helpers.test.ts
+++ b/packages/destination-bigquery/events/__tests__/helpers.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeEvent, normalizeTableId } from '../helpers'
+
+// Test normalizeTableId
+
+describe('normalizeTableId', () => {
+  it('returns pages for page events', () => {
+    expect(normalizeTableId('page')).toBe('pages')
+  })
+})
+
+describe('normalizeEvent', () => {
+  it('flattens nested objects and promotes properties and traits', () => {
+    const event = {
+      userId: '123',
+      properties: { fooBar: 'baz' },
+      traits: { firstName: 'John' },
+      context: { page: { title: 'Home' } },
+    }
+
+    const result = normalizeEvent(event)
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        user_id: '123',
+        foo_bar: 'baz',
+        first_name: 'John',
+        context_page_title: 'Home',
+      })
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- add Vitest unit tests for `normalizeTableId` and `normalizeEvent`
- enable `pnpm test` via Vitest script

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a0fc2e6c83209c7cfb43dd149598