### PR TITLE
Create BigQuery setup runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,26 +44,19 @@ OnePipe provides full Segment HTTP API compatibility:
 - Standardized `DestinationPlugin` interface
 - Support for multiple destinations simultaneously
 
-## BigQuery Setup
+## BigQuery Destination
 
-We provide a convenient setup tool to help you configure BigQuery as a destination:
+OnePipe includes a BigQuery destination plugin for sending events to Google BigQuery with automatic table creation and schema management.
+
+### Quick Setup
 
 ```bash
 pnpm run setup:bigquery
 ```
 
-This interactive CLI tool will:
+This will launch an interactive setup tool from the [@onepipe/destination-bigquery](./packages/destination-bigquery) package.
 
-- Guide you through entering your BigQuery project ID and dataset ID
-- Upload your Google Cloud service account credentials to Cloudflare Secrets
-- Store project/dataset IDs in Cloudflare KV metadata (non-sensitive configuration)
-- Update your `onepipe-configuration.json` automatically
-
-**Requirements:**
-- A Google Cloud project with BigQuery enabled
-- A service account with BigQuery Data Editor permissions
-- The service account JSON key file downloaded locally
-- `wrangler` CLI authenticated (`wrangler auth login`)
+For detailed setup instructions, troubleshooting, and manual configuration options, see the [BigQuery destination documentation](./packages/destination-bigquery/README.md).
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "pnpm -r run build",
     "build:core": "pnpm --filter @onepipe/core run build",
     "build:destination-bigquery": "pnpm --filter @onepipe/destination-bigquery run build",
-    "setup:bigquery": "node setup-bigquery.js"
+    "setup:bigquery": "pnpm --filter @onepipe/destination-bigquery run setup"
   },
   "devDependencies": {
     "@types/lodash": "catalog:dev",

--- a/packages/destination-bigquery/README.md
+++ b/packages/destination-bigquery/README.md
@@ -14,9 +14,39 @@ This package enables event ingestion into Google BigQuery, with auto-creation of
 
 This package is part of the OnePipe monorepo and is not intended for standalone installation. It is loaded as a destination plugin via OnePipe's configuration.
 
-## Configuration
+## Quick Setup
 
-To use this destination, add it to your `onepipe-configuration.json` destinations array:
+We provide an interactive setup tool to help you configure BigQuery:
+
+```bash
+# From workspace root
+pnpm run setup:bigquery
+
+# Or directly from this package
+pnpm --filter @onepipe/destination-bigquery run setup
+
+# Or run the script directly
+cd packages/destination-bigquery && node setup.js
+```
+
+### What the setup tool does:
+
+- 🔍 **Interactive prompts** for BigQuery project ID and dataset ID with validation
+- 🔐 **Automatic credential upload** to Cloudflare Worker Secrets
+- 📊 **KV configuration** for non-sensitive project/dataset IDs
+- 📝 **Auto-configuration** updates `onepipe-configuration.json`
+- ✅ **Validation** ensures proper BigQuery naming conventions
+
+### Requirements:
+
+- A Google Cloud project with BigQuery enabled
+- A service account with BigQuery Data Editor permissions
+- The service account JSON key file downloaded locally
+- `wrangler` CLI authenticated (`wrangler auth login`)
+
+## Manual Configuration
+
+If you prefer manual setup, add this destination to your `onepipe-configuration.json`:
 
 ```json
 {
@@ -30,20 +60,30 @@ To use this destination, add it to your `onepipe-configuration.json` destination
 }
 ```
 
-## Environment Variables
+### Configuration Storage
 
-Set these in your Cloudflare Worker dashboard or via `wrangler secret put`:
-
-**Required:**
-
+**Sensitive data (Cloudflare Worker Secrets):**
 - `GOOGLE_CLOUD_CREDENTIALS` - Base64 encoded service account JSON
+
+**Non-sensitive data (Cloudflare KV metadata):**
 - `BIGQUERY_PROJECT_ID` - Your BigQuery project ID
 - `BIGQUERY_DATASET_ID` - Your BigQuery dataset ID
 
+Set secrets manually:
+```bash
+echo "base64-encoded-credentials" | wrangler secret put GOOGLE_CLOUD_CREDENTIALS
+```
+
+Set KV metadata manually:
+```bash
+wrangler kv key put --binding=KV_BINDING "destination-bigquery" '{"configured":true}' --metadata='{"BIGQUERY_PROJECT_ID":"your-project","BIGQUERY_DATASET_ID":"your-dataset"}'
+```
+
 ## Development
 
-- This package is built with TypeScript.
+- This package is built with TypeScript
 - To build: `pnpm run build` (from the repo root or with workspace filter)
+- Setup script included: `setup.js` (interactive BigQuery configuration tool)
 
 ## Useful Links
 

--- a/packages/destination-bigquery/package.json
+++ b/packages/destination-bigquery/package.json
@@ -6,12 +6,14 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist/**/*"
+    "dist/**/*",
+    "setup.js"
   ],
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "setup": "node setup.js"
   },
   "dependencies": {
     "@maccman/web-auth-library": "catalog:",

--- a/packages/destination-bigquery/setup.js
+++ b/packages/destination-bigquery/setup.js
@@ -3,6 +3,11 @@
 import { readFileSync, writeFileSync } from 'fs';
 import { execSync } from 'child_process';
 import readline from 'readline';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 const KV_BINDING = "KV_BINDING"; // Hardcoded from wrangler.jsonc
 
@@ -11,7 +16,7 @@ if (process.argv.includes('--help') || process.argv.includes('-h')) {
   console.log(`
 🚀 OnePipe BigQuery Setup Tool
 
-Usage: node setup-bigquery.js [options]
+Usage: node setup.js [options]
 
 This interactive tool helps you configure BigQuery for your OnePipe instance.
 
@@ -31,8 +36,8 @@ Requirements:
 • wrangler CLI authenticated (run: wrangler auth login)
 
 Example:
-  pnpm run setup:bigquery
-  node setup-bigquery.js
+  pnpm --filter @onepipe/destination-bigquery run setup
+  cd packages/destination-bigquery && node setup.js
 `);
   process.exit(0);
 }
@@ -152,7 +157,8 @@ async function main() {
     console.log('\n📝 Updating onepipe-configuration.json...');
     
     try {
-      const configPath = './onepipe-configuration.json';
+      // Find the workspace root (go up two levels from packages/destination-bigquery)
+      const configPath = resolve(__dirname, '../../onepipe-configuration.json');
       const config = JSON.parse(readFileSync(configPath, 'utf8'));
       
       // Check if bigquery destination already exists
@@ -174,6 +180,7 @@ async function main() {
       
     } catch (error) {
       console.log('  ⚠️  Could not update configuration file. You may need to manually add the BigQuery destination.');
+      console.log('     Make sure you\'re running this from the workspace root or the packages/destination-bigquery directory.');
     }
 
     // Step 6: Display summary


### PR DESCRIPTION
Add a `create-react-app` style CLI tool to the BigQuery destination package to simplify its configuration and secret management.

The tool guides users through setting up BigQuery by interactively collecting project/dataset IDs and service account credentials. It automatically uploads sensitive credentials as Cloudflare Worker secrets and stores non-sensitive configuration in KV metadata, aligning with the existing BigQuery destination's expected data retrieval pattern. This makes the BigQuery destination a self-sufficient package with integrated setup.